### PR TITLE
Possible way to add coverage to run-all-tests

### DIFF
--- a/script/dev/run-unit-tests
+++ b/script/dev/run-unit-tests
@@ -16,8 +16,15 @@ if [[ -d tests ]] ; then
 
     echo "Configuring SETTINGS to be config.TestConfig"
     echo "Please ensure you have a config.TestConfig in your project"
-    
-    py.test
+
+    # Thinking of doing this below it means all requirements_test.txt
+    # need updating to have pytest-cov
+    # and some of the modules need to be renamed to follow
+    # github repo (app_name) == project-name and python module == projectname
+    # if run-all-tests is to work
+    module_name=$(echo $app_name |  sed 's/-//g' )
+    py.test --cov ${module_name} tests/ --cov-report=term --cov-report=html
+
 else
     echo "No unit tests found in ${app_name}"
 fi


### PR DESCRIPTION
@mwall I've added pytest-cov to search-api (pull request https://github.com/LandRegistry/search-api/pull/10). Not knowing the outcome of all the pull request shenanigans, I'm thinking this would be a reasonable idea. 

I've actually crashed in the change on the-feeder master as well.

One thing that is not connected yet is the report side of things in coveralls.io. I've logged in over there but it's only showing my individual repos not the org ones that I belong to. https://github.com/lemurheavy/coveralls-public/issues/199
