### PR TITLE
use *.landregistry.local domains for all apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ In order to run the development environment locally you will need
 Before using the service ensure that the following line is in your hostfile on the host machine. (Normally in /etc/hosts)
 
 ```
-172.16.42.43    lr-casework lr-service lr-govuk www.gov.uk.dev.landregistryconcept.co.uk land.service.gov.uk.dev.landregistryconcept.co.uk casework.dev.landregistryconcept.co.uk
+172.16.42.43   casework-frontend.landregistry.local landregistry.local geo.landregistry.local html-prototypes.landregistry.local mint.landregistry.local property-frontend.landregistry.local public-titles-api.landregistry.local search-api.landregistry.local service-frontend.landregistry.local system-of-record.landregistry.local the-feeder.landregistry.local 
 ```
+
+This is the most recent list of hosts at the time of writing this. Running ```lr-nginx``` will give you the most recent list.
 
 ### Configuring SSH agent forwarding
 

--- a/script/bin/lr-nginx
+++ b/script/bin/lr-nginx
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Brings nginx configuration up to scratch with the apps list.
+
+APPSLIST=${1:-/vagrant/config/apps}
+if [ ! -e $APPSLIST ] ; then
+  echo "$APPSLIST not found. If you are running this outside of the VM, try with:"
+  echo "$0 config/apps"
+  exit 1
+fi
+
+export DOMAIN="landregistry.local"
+
+# Ensure domain
+sudo perl -pi -e 's/server_name localhost/server_name $ENV{"DOMAIN"}/g' /etc/nginx/sites-available/default
+
+# delete the old configurations
+#for oldapp in $(ls -1 /etc/nginx/sites-available/ |egrep -v default); do
+#  echo "NGINX: deleting $oldapp"
+#  sudo rm -rf /etc/nginx/sites-available/$oldapp >/dev/null
+#  sudo rm -rf /etc/nginx/sites-enabled/$oldapp >/dev/null
+#done
+
+ETCHOSTS=""
+
+# Configure each app
+apps_and_ports=$(cat $APPSLIST | grep -v \# | grep -v '^\s*$')
+for app_and_port in ${apps_and_ports}; do
+  app=$(echo ${app_and_port} | cut -d':' -f1)
+  port=$(echo ${app_and_port} | cut -d':' -f2)
+  if [ $port == 0 ]; then
+    continue;
+  fi
+
+  # delete the old configurations
+  echo "NGINX: deleting previous configuration of $app"
+  sudo rm -rf /etc/nginx/sites-available/$app >/dev/null
+  sudo rm -rf /etc/nginx/sites-enabled/$app >/dev/null
+
+  # re-create the configuration
+  sudo tee "/etc/nginx/sites-available/$app" > /dev/null <<EOF
+server {
+  server_name $app.$DOMAIN;
+  location / {
+    proxy_pass http://localhost:$port;
+    proxy_set_header X-Real-IP \$remote_addr;
+    proxy_set_header Host \$http_host;
+  }
+}
+EOF
+  # re-link
+  echo "NGINX: creating $app with port $port"
+  sudo ln -s /etc/nginx/sites-available/$app /etc/nginx/sites-enabled/$app
+  ETCHOSTS="$ETCHOSTS $app.$DOMAIN"
+done
+
+echo "NGINX: restarting"
+sudo service nginx restart
+
+echo "NGINX: add the following line to your /etc/hosts"
+echo "172.16.42.43 $ETCHOSTS"

--- a/script/provision-vm
+++ b/script/provision-vm
@@ -27,6 +27,9 @@ apt-get install -qy binutils libproj-dev gdal-bin libgdal-dev libgeos-3.4.2 libp
 echo "Setting up docker"
 apt-get install -o Dpkg::Options::="--force-confnew" -qy lxc-docker-1.0.0
 
+echo "Setting up nginx"
+apt-get install -qy  nginx
+
 echo 'export DOCKER_OPTS="-H unix:///var/run/docker.sock -H tcp://0.0.0.0:4243"' > /etc/default/docker
 echo 'export DOCKER_HOST=tcp://0.0.0.0:4243' > /home/vagrant/.bash_profile
 stop docker
@@ -89,6 +92,8 @@ if [[ ! -d ./apps ]] ; then
 	echo "Bootstrapping environment"
 	lr-bootstrap
 fi
+
+lr-nginx
 EOF
 
 echo "0.0.0.0  lr-dev" >> /etc/hosts


### PR DESCRIPTION
As discussed, Mr @mwall 

If you like what you see, I'll go through all the apps and change all `environment.sh` to point to these `landregistry.local` domains. What happens is that the apps on the VM currently gives you `localhost:xxxx` links to click on, and these need to be reconfigured.
