### PR TITLE
Fix Provision Failing due to Git Clone Prompt

### DIFF
--- a/script/provision-vm
+++ b/script/provision-vm
@@ -97,6 +97,7 @@ lr-nginx
 EOF
 
 echo "Bootstrapping environment"
+echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
 /vagrant/script/bin/lr-bootstrap
 
 echo "Configuring nginx"


### PR DESCRIPTION
Git is prompting for you to accept the host, which can’t be done as
part of the provision script, this adds an exception to github.com and
allows the provisioning script to successfully complete.
